### PR TITLE
Fix deprecated imports from ``werkzeug`` and ``collections``.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Click==7.0
 Flask==1.0.2
-Flask-WTF==0.14.2
+Flask-WTF==0.14.3
 ipython==7.5.0
 Jinja2==2.10.1
 nltk==3.4.5


### PR DESCRIPTION
Looks like Flask-WTF has a newer version that fixes deprecated imports:

https://github.com/lepture/flask-wtf/commit/dc786301c5b6c10a8b1b256d9820c8a7a932d99c#diff-b0508adba031c447ece5a495a136a3d1